### PR TITLE
Default timeOutLimit 30 dakika olarak belirlendi

### DIFF
--- a/src/Payment.php
+++ b/src/Payment.php
@@ -23,7 +23,7 @@ class Payment
     /**
      * @var int
      */
-    private $timeOutLimit = 1;
+    private $timeOutLimit = 30;
 
     /**
      * @var bool


### PR DESCRIPTION
Default timeOutLimit paytr dökümantasyonunda ki default değer olan 30 dakika olarak belirlendi. 1 Dakika nedeniyle yaşanan sorunlar ortadan kaldırıldı.